### PR TITLE
Allow to customize base url per each request

### DIFF
--- a/lib/consul/http/client.ex
+++ b/lib/consul/http/client.ex
@@ -4,6 +4,10 @@ defmodule Consul.HTTP.Client do
 
   use HTTPoison.Base
 
+  def process_url("http" <> _rest = url) do
+    url
+  end
+
   def process_url(query) do
     "http://#{base_url()}/#{query}"
   end
@@ -60,6 +64,12 @@ defmodule Consul.HTTP.Client do
   end
 
   def request(method, url, body \\ "", headers \\ [], opts \\ []) do
+    {url, opts} =
+      case Keyword.get(opts, :base_url) do
+        "" <> custom_base_url -> {custom_base_url <> url, Keyword.drop(opts, [:base_url])}
+        nil -> {url, opts}
+      end
+
     response = super(method, url, body, headers, opts)
 
     Logger.info(fn ->

--- a/lib/consul/http/raw.ex
+++ b/lib/consul/http/raw.ex
@@ -405,7 +405,8 @@ defmodule Consul.HTTP.Raw do
                       :proxy_auth,
                       :ssl,
                       :follow_redirect,
-                      :max_redirect]
+                      :max_redirect,
+                      :base_url]
 
   endpoints = endpoints.v1
   Enum.each(endpoints, fn(endpoint) ->


### PR DESCRIPTION
In a scenario with multiple consul machines to hit in a distributed cluster, you may want to dynamically choose what server to hit. With the actual code it's impossible because it is hard-coded to have only one base url set by the environment.

This also allows you to not rely on config when setting the base url.

I want to use this library but without this change it's impossible for me and I don't want to have a forked outdated version (also this can be used for others), the change is very small, straightforward and retro-compatible. I can also add some docs if you like the idea.